### PR TITLE
The use of href="javascript:void(0)" throws a warning that React will…

### DIFF
--- a/src/components/Footer/PrivacySettingsLink.jsx
+++ b/src/components/Footer/PrivacySettingsLink.jsx
@@ -22,7 +22,7 @@ class _PrivacySettingsLink extends React.PureComponent {
       <>
         <a
           href={' '}
-          onClick={event => this.openDialog(event)}
+          onClick={this.openDialog}
           className="ds-u-display--inline-block"
         >
           {this.props.t('footer.privacySettings')}

--- a/src/components/Footer/PrivacySettingsLink.jsx
+++ b/src/components/Footer/PrivacySettingsLink.jsx
@@ -8,7 +8,8 @@ class _PrivacySettingsLink extends React.PureComponent {
     this.state = { showDialog: false };
   }
 
-  openDialog = () => {
+  openDialog = event => {
+    event.preventDefault();
     this.setState({ showDialog: true });
   };
 
@@ -20,8 +21,8 @@ class _PrivacySettingsLink extends React.PureComponent {
     return (
       <>
         <a
-          href="javascript:void(0)"
-          onClick={this.openDialog}
+          href={' '}
+          onClick={event => this.openDialog(event)}
           className="ds-u-display--inline-block"
         >
           {this.props.t('footer.privacySettings')}

--- a/src/components/Footer/PrivacySettingsLink.jsx
+++ b/src/components/Footer/PrivacySettingsLink.jsx
@@ -8,8 +8,7 @@ class _PrivacySettingsLink extends React.PureComponent {
     this.state = { showDialog: false };
   }
 
-  openDialog = event => {
-    event.preventDefault();
+  openDialog = () => {
     this.setState({ showDialog: true });
   };
 
@@ -20,13 +19,9 @@ class _PrivacySettingsLink extends React.PureComponent {
   render() {
     return (
       <>
-        <a
-          href={' '}
-          onClick={this.openDialog}
-          className="ds-u-display--inline-block"
-        >
+        <button onClick={this.openDialog}>
           {this.props.t('footer.privacySettings')}
-        </a>
+        </button>
         {this.state.showDialog && (
           <PrivacySettingsDialog onExit={this.closeDialog} />
         )}

--- a/src/styles/components/_Footer.scss
+++ b/src/styles/components/_Footer.scss
@@ -23,6 +23,18 @@
     padding-right: $spacer-half;
   }
 
+  // "Privacy Settings" link is a button
+  button {
+    border: none;
+    background-color: inherit;
+    color: inherit;
+    text-decoration: none;
+    font-family: inherit;
+    font-size: inherit;
+    padding: 0;
+    padding-right: $spacer-half;
+  }
+
   &::after {
     content: '·';
   }


### PR DESCRIPTION
… block javascript URLs in a future version.  On a semantic level, this "link" shouldn't really be a link at all - because it's not performing the function of an <a> tag.  Ideally, it should be a <button> styled to look as text, because the action performed upon click is not based upon browser navigation.