### PR TITLE
[WNMGPCII-1166] Web accessibility updates for menu modal

### DIFF
--- a/src/styles/components/_Menu.scss
+++ b/src/styles/components/_Menu.scss
@@ -29,13 +29,13 @@
 }
 
 .hc-c-menu__link {
-  color: $color-primary-darker;
+  color: $color-primary-darker !important;
   padding: $spacer-1;
   text-decoration: none;
 
   &:hover,
   &:focus {
-    color: $color-primary-darkest;
+    color: $color-primary-darkest !important;
   }
 }
 
@@ -78,8 +78,10 @@
  */
 .hc-c-header--logged-in .hc-c-menu__content,
 .hc-c-header--minimal .hc-c-menu__content {
-  background-color: $color-primary-alt-light;
-  color: $color-base;
+  background-color: $color-white;
+  border: 1px solid $color-gray-dark;
+  box-shadow: 7.5px 7.5px 17px 7.5px $color-gray-light;
+  color: $color-primary-darker;
 
   @media (min-width: $width-sm) {
     // Span only part of non-mobile screens


### PR DESCRIPTION
Link:  https://jira.cms.gov/browse/WNMGPCII-1166

@pwolfert 

Description:  The two links in the header (menu items; Log in | Lang) use the color `#428bca` on a blue background. This color only has a 3.63:1 contrast ratio. The color also isn’t one from the CMS design system.

Proposed changes:  Update menu css to use a white background and select color palette from CMS design system to improve contrast ratio.