### PR TITLE
[NO-TICKET] Add another note to publishing documentation

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -3,7 +3,9 @@
 ## 1) Publish to NPM
 
 1. Run `yarn release` to build a release branch from the HEAD of the master branch. The pre-publish script will prompt you for the version number change. If the script finishes successfully, move on to the next step.
-2. Run `npm publish --tag latest` to publish the release to NPM. Note that this cannot be undone.
+2. Run `npm publish --tag latest` to publish the release to NPM.
+    - Note that this cannot be undone.
+    - If someone else is doing the publish step, make sure to check out the git tag created in the previous step and `yarn build` before publishing.
 3. Create a pull request on GitHub for the release branch so it can be merged into the master branch.
 
 **Note:** You must be logged in to an NPM account with publishing rights on the `cmsgov` organization for this to work. To request access, create a [Jira ticket on the QPP Tools and Access board](https://jira.cms.gov/browse/QTA-847) with your EUA and NPM username. Reach out on the [`#hcgov-design-system` channel](https://cmsgov.slack.com/archives/C0111BVM1LZ) for any questions on this process.


### PR DESCRIPTION
Add an extra note to the publishing documentation for special situations. This is the scenario we had today where @sdbars was making the release but did not yet have npm access to publish. I published to npm, and I noticed we had nothing in our documentation for situations where we aren't immediately publishing to npm from the same machine after cutting a release.