### PR TITLE
[WNMGPCII-1346] Update design system footer to include trademark

### DIFF
--- a/src/components/Footer/LogosRow.jsx
+++ b/src/components/Footer/LogosRow.jsx
@@ -19,7 +19,11 @@ const LogosRow = function (props) {
         </div>
         <div className="ds-l-col ds-l-col--9 ds-l-sm-col--10 ds-l-md-col--auto">
           <p className="ds-u-font-size--small ds-u-color--muted ds-u-measure--base ds-u-margin--0">
-            {props.t('footer.address')}
+            {props.t('footer.address1')}
+            <span className="registered-symbol">
+              <sup>&#174;</sup>
+            </span>{' '}
+            {props.t('footer.address2')}
           </p>
         </div>
         <div className="ds-l-col ds-l-col--12 ds-l-lg-col--auto ds-u-lg-margin-top--0 ds-u-margin-top--2 ds-u-margin-left--auto">

--- a/src/components/Footer/__snapshots__/LogosRow.test.jsx.snap
+++ b/src/components/Footer/__snapshots__/LogosRow.test.jsx.snap
@@ -23,7 +23,16 @@ exports[`LogosRow renders logos and address 1`] = `
       <p
         className="ds-u-font-size--small ds-u-color--muted ds-u-measure--base ds-u-margin--0"
       >
-        footer.address
+        footer.address1
+        <span
+          className="registered-symbol"
+        >
+          <sup>
+            ®
+          </sup>
+        </span>
+         
+        footer.address2
       </p>
     </div>
     <div

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -10,7 +10,8 @@
     "linkingPolicy": "Linking Policy",
     "usingThisSite": "Using This Site",
     "plainWriting": "Plain Writing",
-    "address": "A federal government website managed and paid for by the U.S. Centers for Medicare & Medicaid Services. 7500 Security Boulevard, Baltimore, MD 21244. Health Insurance Marketplace is a registered trademark of the Department of Health and Human Services."
+    "address1": "A federal government website managed and paid for by the U.S. Centers for Medicare & Medicaid Services. 7500 Security Boulevard, Baltimore, MD 21244. Health Insurance Marketplace",
+    "address2": "is a registered trademark of the Department of Health and Human Services."
   },
   "header": {
     "close": "Close",

--- a/src/locale/es.json
+++ b/src/locale/es.json
@@ -10,7 +10,8 @@
     "linkingPolicy": "Política de enlaces",
     "usingThisSite": "Usando este sitio",
     "plainWriting": "Lenguaje Sencillo",
-    "address": "Un sitio Web del gobierno federal administrado y pagado por los Centros de Servicios de Medicare y Medicaid. 7500 Security Boulevard, Baltimore, MD 21244"
+    "address1": "Un sitio Web del gobierno federal administrado y pagado por los Centros de Servicios de Medicare y Medicaid. 7500 Security Boulevard, Baltimore, MD 21244. Mercado de Seguros Médicos",
+    "address2": "es una marca registrada del Departamento de Salud y Servicios Humanos."
   },
   "header": {
     "close": "Cerca",

--- a/src/styles/components/_Logo.scss
+++ b/src/styles/components/_Logo.scss
@@ -19,3 +19,7 @@
 .hc-c-logo__gov {
   fill: $color-gray;
 }
+
+.registered-symbol {
+  font-size: 0.6rem;
+}


### PR DESCRIPTION
Summary of changes:

- Add registered logo after Health Insurance Marketplace (2nd sentence in footer)
- Update the Spanish content to include 2nd sentence

Current footer:  

English

<img width="976" alt="Screen Shot 2021-05-14 at 1 17 56 PM" src="https://user-images.githubusercontent.com/77984600/118306084-e42af480-b4b6-11eb-9b81-1050cb2f01da.png">

Spanish

<img width="976" alt="Screen Shot 2021-05-14 at 1 18 54 PM" src="https://user-images.githubusercontent.com/77984600/118306121-f73dc480-b4b6-11eb-8f05-ab8135174124.png">

Updated footer:

English

<img width="976" alt="Screen Shot 2021-05-14 at 1 19 40 PM" src="https://user-images.githubusercontent.com/77984600/118306224-19374700-b4b7-11eb-9566-144b79b789be.png">

Spanish

<img width="976" alt="Screen Shot 2021-05-14 at 1 19 52 PM" src="https://user-images.githubusercontent.com/77984600/118306231-1d636480-b4b7-11eb-9f41-9939ab59dd1b.png">

