### PR TITLE
Release 4.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cmsgov/ds-healthcare-gov",
-  "version": "4.9.0",
+  "version": "4.9.1",
   "publishConfig": {
     "tag": "latest",
     "access": "public"


### PR DESCRIPTION
Patch release to version 4.9.1 which updates the footer to include a registered trademark symbol.