### PR TITLE
[NO-TICKET] disable focus styles

### DIFF
--- a/src/styles/settings/_override.build.scss
+++ b/src/styles/settings/_override.build.scss
@@ -1,2 +1,5 @@
 // Set $ds-include-choice-error-highlight to automatically add an error highlight to choice components inside a ChoiceList with an errorMessage.
 $ds-include-choice-error-highlight: true;
+
+// Disabling the design system focus styles
+$ds-include-focus-styles: false;


### PR DESCRIPTION
Disabling the focus styles at the Healthcare level as they are not ready to start using the focus styles yet.

**How to test**
Run the Healthcare design system locally and see that the focus styles match what is on the live documentation site