### PR TITLE
Revert "[WNMGDS-920] Set up Healthcare gov focus style (#40)"

### DIFF
--- a/src/styles/components/_Button.scss
+++ b/src/styles/components/_Button.scss
@@ -26,4 +26,26 @@
     background-color: $active-color;
     border-color: transparent;
   }
+
+  @if $ds-include-focus-styles {
+    &:focus,
+    &.ds-c-button--focus {
+      background-color: $focus-color;
+      border-color: transparent;
+      color: $color-base;
+    }
+
+    // Make sure active overrides focus styles
+    &:active:focus,
+    &.ds-c-button--active:focus {
+      background-color: $active-color;
+      box-shadow: none;
+    }
+  } @else {
+    &:focus,
+    &.ds-c-button--focus {
+      border-color: transparent;
+      color: $color-white;
+    }
+  }
 }

--- a/src/styles/components/_Header.scss
+++ b/src/styles/components/_Header.scss
@@ -3,6 +3,10 @@
   background-color: $color-primary;
   color: $color-white;
 
+  .hc-c-logo-link:focus {
+    outline: 2px dashed $color-white;
+  }
+
   .hc-c-logo__health,
   .hc-c-logo__care,
   .hc-c-logo__gov {

--- a/src/styles/settings/_override.build.scss
+++ b/src/styles/settings/_override.build.scss
@@ -1,2 +1,5 @@
 // Set $ds-include-choice-error-highlight to automatically add an error highlight to choice components inside a ChoiceList with an errorMessage.
 $ds-include-choice-error-highlight: true;
+
+// Disabling the design system focus styles
+$ds-include-focus-styles: false;

--- a/src/styles/settings/_override.color.scss
+++ b/src/styles/settings/_override.color.scss
@@ -24,7 +24,3 @@ $color-secondary: #b20000;
 $color-secondary-dark: #8d0000;
 $color-secondary-light: #e59393;
 $color-secondary-lightest: #f8dddd;
-
-// Focus colors
-$color-focus-light: #fff;
-$color-focus-dark: #dd3603;


### PR DESCRIPTION
We need to bump the core library and do a release of HCgov to address a defect one of our users encountered. To prevent focus styles from being implemented by some teams too early, I've run `git revert` on the specific commit to "remove" focus styles from `master` so we can do a clean release of HCgov that fixes their issues.

Don't be scared: These focus styles still exist in the newly created `development` branch and once we cut a release for HCgov I will revert this revert on `master` (sounds crazy, but it's legit I promise) to preserve the git history of the project. 
