### PR TITLE
[WNMGDS-1081] hiding logged out menu on larger screens

### DIFF
--- a/src/styles/components/_Header.scss
+++ b/src/styles/components/_Header.scss
@@ -146,6 +146,7 @@ Header dropdown menu - Shared across header variations
   right: 0;
   top: 0;
   z-index: 1;
+
   @media (min-width: $width-sm) {
     // Span only part of non-mobile screens
     left: auto;
@@ -157,5 +158,13 @@ Header dropdown menu - Shared across header variations
     display: block;
     padding: $spacer-1;
     text-decoration: none;
+  }
+}
+
+@media (min-width: $width-sm) {
+  .hc-c-header--logged-out {
+    .hc-c-menu__content {
+      display: none;
+    }
   }
 }


### PR DESCRIPTION
## Summary
For the logged out header, if user is on a small screen and opens the menu, then resizes window to a larger screen size, the menu stays open.

### Fixed
Updated the Header CSS to hide the menu for logged out header on larger screens.

## How to test

1. Run doc site and navigate to Header pattern, React example.
2. Make screen small
3. On the "Logged Out" example, click the "menu" button
4. Without clicking anything else, make screen wider
5. Confirm that menu is hidden on larger screens
6. Resize back to smaller window size, confirm that menu appears again
7. Confirm that this change does not affect the logged in header
