### PR TITLE
[WNMGDS-1086] setting focus style for footer privacy setting link

### DIFF
--- a/src/styles/components/_Footer.scss
+++ b/src/styles/components/_Footer.scss
@@ -32,6 +32,10 @@
     padding: 0;
     padding-right: $spacer-half;
     text-decoration: none;
+
+    &:focus {
+      @include focus-styles;
+    }
   }
 
   &::after {


### PR DESCRIPTION
## Summary
For the footer, the 'Privacy Settings' link was not getting the new focus styling applied

### Fixed
Updated styles so that 'Privacy Settings' will get the same focus treatment as other links in list

## How to test
1. Navigate to Patterns > Footer in doc site
2. Tab through links in footer
3. Confirm that 'Privacy Settings' link has the same focus styling as other links

<img width="1739" alt="Screen Shot 2021-09-21 at 11 28 35 AM" src="https://user-images.githubusercontent.com/33579665/134220280-8cd764b7-aca5-4737-8b45-490401433894.png">

