### PR TITLE
Fix footer SR bug

### DIFF
--- a/src/styles/components/_Footer.scss
+++ b/src/styles/components/_Footer.scss
@@ -38,8 +38,16 @@
     }
   }
 
-  &::after {
-    content: '·';
+  &:not(:last-child)::after {
+    --marker-size: 2px;
+    background-color: currentColor;
+    border-radius: 50%;
+
+    content: '';
+    display: inline-block;
+    height: var(--marker-size);
+    vertical-align: middle;
+    width: var(--marker-size);
   }
 
   &:first-child a {
@@ -48,9 +56,5 @@
 
   &:last-child {
     margin-right: 0;
-  }
-
-  &:last-child::after {
-    content: '';
   }
 }

--- a/src/styles/components/_Footer.scss
+++ b/src/styles/components/_Footer.scss
@@ -1,7 +1,5 @@
 @import './Logo';
 
-$hc-c-footer-list-marker-size: 2px;
-
 .hc-c-footer {
   a {
     color: $color-muted;
@@ -41,6 +39,8 @@ $hc-c-footer-list-marker-size: 2px;
   }
 
   &:not(:last-child)::after {
+    $hc-c-footer-list-marker-size: 2px;
+
     background-color: currentColor;
     border-radius: 50%;
     content: '';

--- a/src/styles/components/_Footer.scss
+++ b/src/styles/components/_Footer.scss
@@ -1,5 +1,7 @@
 @import './Logo';
 
+$hc-c-footer-list-marker-size: 2px;
+
 .hc-c-footer {
   a {
     color: $color-muted;
@@ -39,15 +41,13 @@
   }
 
   &:not(:last-child)::after {
-    --marker-size: 2px;
     background-color: currentColor;
     border-radius: 50%;
-
     content: '';
     display: inline-block;
-    height: var(--marker-size);
+    height: $hc-c-footer-list-marker-size;
     vertical-align: middle;
-    width: var(--marker-size);
+    width: $hc-c-footer-list-marker-size;
   }
 
   &:first-child a {


### PR DESCRIPTION
[Jira ticket](https://jira.cms.gov/browse/WNMGDS-1085)

### Problem 

In footer pattern, the "." delimiter on the footer links is read aloud as "middle dot" on screen readers. Since this is a decorative element separating the links, it shouldn't be read out as that causes unnecessary noise.

### Solution

Replace the `::after { content: "." }` rule with decorative CSS (kinda like a tiny div with a big border-radius to simulate a "middle dot").

### Recreate

1. Running this branch locally on Chrome or Safari, navigate to `/example/patterns.footer/`
2. Open VoiceOver application and read contents of footer (you shouldn't hear "middle dot" read aloud)

