### PR TITLE
[WNMGDS-1116] Fix secondary button bug when button is both focused and active

### DIFF
--- a/src/styles/components/_Button.scss
+++ b/src/styles/components/_Button.scss
@@ -26,4 +26,10 @@
     background-color: $active-color;
     border-color: transparent;
   }
+  // Make sure active overrides focus styles
+  &:active:focus,
+  &.ds-c-button--active:focus {
+    background-color: $active-color;
+    box-shadow: none;
+  }
 }


### PR DESCRIPTION
## Summary
When the secondary button is both active and focused it appears to disappear. (This is a style issue) 


**Before fix**
The button background is white and the text is white (which looks like a disappearing button) 
![Screen Shot 2021-09-30 at 11 57 16 AM](https://user-images.githubusercontent.com/1449852/135489927-86f8023e-d57e-4a1f-a52e-316ecdfa4b87.png)

**After fix**
The button background is a darker blue and the text is white (no more disappearing button) 
![Screen Shot 2021-09-30 at 11 56 17 AM](https://user-images.githubusercontent.com/1449852/135490033-dc820674-79b3-4714-89fc-213709da82fd.png)

### Added
Added a active:focused style for the secondary button 

## How to test
- Run the HCgov doc site locally and set the secondary button to be both active and focused. 
- The secondary button should appear as dark blue and no longer be disappearing 👻 

