### PR TITLE
[NO-TICKET] Run release/publish scripts directly instead of through yarn

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -46,7 +46,7 @@ When the cherry-picking has been resolved, you can move on to the next step.
 Run
 
 ```
-yarn release
+./release.sh
 ```
 
 and go through the interactive prompt to choose the release version. See notes on [SemVer release format](#versioning). It will automatically apply the version bumps, commit it to a branch, and tag it as a release.
@@ -56,7 +56,7 @@ and go through the interactive prompt to choose the release version. See notes o
 Find out your tag name from the previous step and run
 
 ```
-yarn publish-release <tag name>
+./publish-release.sh <tag name>
 ```
 
 After successfully publishing, there will be three zip files for uploading to the GitHub release in the next step.

--- a/package.json
+++ b/package.json
@@ -16,8 +16,6 @@
     "updateSnapshot": "yarn cmsds test ./src --updateSnapshot",
     "lint": "yarn cmsds lint ./src ./docs",
     "gh-pages": "yarn build && gh-pages -d './docs/dist'",
-    "release": "./release.sh",
-    "publish-release": "./publish-release.sh",
     "prepare": "husky install"
   },
   "main": "dist/components/index.js",


### PR DESCRIPTION
## Summary
Run the release scripts directly since running in yarn breaks npm publish. This works in core, but it also executes through lerna. I don't want to hunt down why this fails in yarn right now, especially since we hope to move this into the monorepo soon where it won't be a problem.